### PR TITLE
Ensuring test builds succeed without development dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - 2.2.1
+bundler_args: "--without development"
 env:
   global:
   - secure: "FrUtnEwOKmTSy4wNhEU9QscXBkjRTZfZy5DAJkhcB5xVitdKRuR99OC5rvoVgodEDmxvMRdFsDHcVqz2g+AfrCdQfx3tBt2ogML13abgMnNapa5fyrO3u6/ZsN1gPkOyBYsQ3x6IxE9FwUKnwZvf5nkXj+SMWi516MoDXenS8Ic="

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,15 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :test do
+  gem 'rspec'
+  gem 'rspec-its'
+
+  gem 'guard'
+  gem 'guard-rspec'
+
+  gem 'simplecov'
+  gem 'simplecov-rcov'
+  gem 'coveralls'
+end

--- a/lib/slack_scratcher.rb
+++ b/lib/slack_scratcher.rb
@@ -1,9 +1,6 @@
 $LOAD_PATH.unshift File.dirname(__FILE__)
 require 'logger'
-require 'dotenv'
 require 'faraday'
-
-Dotenv.load
 
 # Importing slack logs from exported fils or API to elasticsearch or
 # other detastores

--- a/slack_scratcher.gemspec
+++ b/slack_scratcher.gemspec
@@ -36,16 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('dotenv')
   spec.add_development_dependency('rake')
 
-  # for Test
-  spec.add_development_dependency('guard')
-  spec.add_development_dependency('guard-rspec')
-  spec.add_development_dependency('rspec')
-  spec.add_development_dependency('rspec-its')
-  spec.add_development_dependency('simplecov')
-  spec.add_development_dependency('simplecov-rcov')
-
-  # Test Coverage
-  spec.add_development_dependency('coveralls')
+  # Test dependencies can be found in the Gemfile
 
   # Style Guide
   spec.add_development_dependency('rubocop')


### PR DESCRIPTION
- Requesting builds w/o development dependencies
- Moving test dependencies into Gemfile to allow for installation with test, but without development
- Removing Dotenv
